### PR TITLE
Handle 5xx

### DIFF
--- a/terra_sdk/client/lcd/lcdclient.py
+++ b/terra_sdk/client/lcd/lcdclient.py
@@ -89,14 +89,12 @@ class AsyncLCDClient:
         ) as response:
             try:
                 result = await response.json(content_type=None)
-                if not 200 <= response.status < 299:
-                    raise LCDResponseError(
-                        message=result.get("error"), response=response
-                    )
-                self.last_request_height = result.get("height")
-                return result if raw else result["result"]
             except JSONDecodeError:
                 raise LCDResponseError(message=str(response.reason), response=response)
+            if not 200 <= response.status < 299:
+                raise LCDResponseError(message=result.get("error"), response=response)
+        self.last_request_height = result.get("height")
+        return result if raw else result["result"]
 
     async def _post(
         self, endpoint: str, data: Optional[dict] = None, raw: bool = False
@@ -106,14 +104,12 @@ class AsyncLCDClient:
         ) as response:
             try:
                 result = await response.json(content_type=None)
-                if not 200 <= response.status < 299:
-                    raise LCDResponseError(
-                        message=result.get("error"), response=response
-                    )
-                self.last_request_height = result.get("height")
-                return result if raw else result["result"]
             except JSONDecodeError:
                 raise LCDResponseError(message=str(response.reason), response=response)
+            if not 200 <= response.status < 299:
+                raise LCDResponseError(message=result.get("error"), response=response)
+        self.last_request_height = result.get("height")
+        return result if raw else result["result"]
 
     async def __aenter__(self):
         return self


### PR DESCRIPTION
Handle responses that are not json.
Previously would raise a `json.JSONDecodeError` making it hard to know the context, now raise a `terra_sdk.exceptions.LCDResponseError`

Non json answers can come from a multitude of scenarios. For example, response from a load balance/reverse proxy in front of lcd.